### PR TITLE
Add section "alternatives"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A github action that retrieves the pull request branch name and sets it in the output for other actions to use.
 
-# Usage
+## Usage
 
 ```yaml
 - uses: mdecoleman/pr-branch-name2.0.0
@@ -12,6 +12,11 @@ A github action that retrieves the pull request branch name and sets it in the o
 - run: echo ${{ steps.vars.outputs.branch }}
 ```
 
-# License
+## Alternatives
+
+This action focuses on determing the branch name in the current action context.
+In case one needs the target branch of the PR or the default branch, one can try [`branch-names`](https://github.com/tj-actions/branch-names#branch-names).
+
+## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE)


### PR DESCRIPTION
This action is the number one google hit. There is another action with more functionality.

I personally like if tools link alternatives, because this helps the searcher for the best tool. And a tool being aware of its alternatives is usally the better one :)

I also converted `h1` headings to `h2` to fix [MD025](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md).